### PR TITLE
Added Best Practice guideline for partials/includes

### DIFF
--- a/best_practices/templates.rst
+++ b/best_practices/templates.rst
@@ -53,6 +53,15 @@ scattered through lots of bundles.
 
     Use lowercased snake_case for directory and template names.
 
+.. best-practice::
+
+    Use a prefixed underscore for partial templates in template names.
+
+You often want to reuse template code using the ``include`` function to avoid
+redundant code. To determine those partials easily in the filesystem you should
+prefix partials and any other template without HTML body or ``extends`` tag
+with a single underscore.
+
 Twig Extensions
 ---------------
 


### PR DESCRIPTION
Hi there,

I was wondering if there are no Best Practice guide for partials/includes. So I would recommend to use a single prefixed underscore to determine such partials easily like in the Symfony demo application: https://github.com/symfony/demo/tree/master/templates/blog

I saw often other solutions like `@SomeBundle:Partials/post_form.html.twig`. But I like the approach from the Symfony demo application, so it should be a Best Practice guideline :)

Regards,
Timon